### PR TITLE
docs: split README, wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,4 @@
-# Pack fonts for PDF export
-
-For a quality PDF output, it is essential that our library has access to the same fonts that the browser uses to display the elements that you need to output.  Otherwise the layout of the PDF will look broken and non-ASCII characters might not be displayed properly.
-
-Declaring fonts is somewhat painful:
-
-- you must write the appropriate `@font-face` rules in the CSS
-- you must host the CSS file on the same domain as the page
-- you must keep the font files on the same domain too, or otherwise, make sure that the server hosting the fonts sends the proper [HTTP access control (CORS) headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS).
-- you cannot serve the page over `file:///` URL-s (which can be useful, for example in mobile apps)
+# Pack fonts as inline scripts
 
 This module packs one or more fonts into JavaScript code.  You can then load that code with a `<script>` tag and it will work no matter where you store it (no need for CORS headers).  It will also work if the page is loaded on `file://` URL, because no AJAX request is needed to load the fonts in Kendo PDF library.
 
@@ -52,28 +43,28 @@ Our module bundles the fonts into JS code and dumps it on standard output.  In t
       ...
       <script src="fonts.js"></script>
 
-Placing it in `<head>` is not a strict requirement, but I recommend it.  The script will inject `@font-face` declarations into the page with `document.write`.  Do not attempt to load this with RequireJS or similar tools, it will not work.
+Placing it in `<head>` is not a strict requirement, but we recommend it.  The script will inject `@font-face` declarations into the page with `document.write`.  Do not attempt to load this with RequireJS or similar tools, it will not work.
 
 Like any compromise, this method has its advantages and drawbacks:
 
 Pros:
 
-- PRO: a single HTTP request is needed to load all the fonts you use in a page
+- Single HTTP request is needed to load all the fonts you use in a page
 
-- PRO: it has no domain security restrictions
+- No domain security restrictions
 
-- PRO: the fonts will be available before your page renders (no flickering)
+- The fonts will be available before your page renders (no flickering)
 
 Cons:
 
-- CON: the size of the generated file is greater than the sum of the sizes of the binary `.ttf` files.  But serving JS with gzip compression (which you should do anyway) almost makes up for the difference.
+- The size of the generated file is greater than the sum of the sizes of the binary `.ttf` files.  But serving JS with gzip compression (which you should do anyway) almost makes up for the difference.
 
-- CON: all fonts will be loaded, even if only a few are needed.
+- All fonts will be loaded, even if only a few are needed.
 
-- CON: loading the generated `<script>` spends, on average, 15 milliseconds per font, to create a binary `Blob` from BASE64.  I did not benchmark the classic method (loading the `.ttf` files as usual with plain CSS) but I think it's safe to say that should be a bit faster.
+- Loading the generated `<script>` spends, on average, 15 milliseconds per font, to create a binary `Blob` from BASE64.  This should be faster than the classic method - loading the `.ttf` files as usual with plain CSS.
 
 ## Browser support
 
-The generated bundle should work in all browsers that support [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob).  I tested it on IE 10, Firefox, Chrome.
+The generated bundle should work in all browsers that support [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob).  Tested on IE 10, Firefox, Chrome.
 
-A workaround should be possible for IE9, but not yet implemented.
+A workaround should be possible for IE9, but it's not yet implemented.

--- a/README.md
+++ b/README.md
@@ -77,5 +77,3 @@ This approach demonstrates the following advantages and disadvantages:
 ## Browser Support
 
 The generated bundle works in all browsers that support [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob). It is tested against Interenet Explorer 10, Firefox, and Chrome.
-
-The team are also working on the implementation of a workaround for Internet Explorer 9.

--- a/README.md
+++ b/README.md
@@ -1,70 +1,81 @@
-# Pack fonts as inline scripts
+# Pack Fonts as Inline Scripts
 
-This module packs one or more fonts into JavaScript code.  You can then load that code with a `<script>` tag and it will work no matter where you store it (no need for CORS headers).  It will also work if the page is loaded on `file://` URL, because no AJAX request is needed to load the fonts in Kendo PDF library.
+## Overview 
 
-## Usage
+Thе `kendo-pack-fonts` module packs one or more fonts into JavaScript code. In this way, you can load that code by using a `<script>` tag. 
 
-Put your `.ttf` files in a directory, and add a file named `fonts.json` file with contents similar to this:
+The packed code works:  
+* Regardless of the location you store it&mdash;this means that you do not need CORS headers.   
+* Even if the page is loaded to the `file://` URL, because you do not need an AJAX request to load the fonts into the Kendo UI PDF library.   
 
-    [
-        {
-            "fontFamily": "DejaVu Sans",
-            "fontWeight": "normal",
-            "fontStyle": "normal",
-            "src": "./DejaVuSans.ttf"
-        },{
-            "fontFamily": "DejaVu Sans",
-            "fontWeight": "bold",
-            "fontStyle": "normal",
-            "src": "./DejaVuSans-Bold.ttf"
-        },{
-            "fontFamily": "DejaVu Sans",
-            "fontWeight": "normal",
-            "fontStyle": "italic",
-            "src": "./DejaVuSans-Oblique.ttf"
-        },{
-            "fontFamily": "DejaVu Sans",
-            "fontWeight": "bold",
-            "fontStyle": "italic",
-            "src": "./DejaVuSans-BoldOblique.ttf"
-        }
-    ]
+## Basic Usage
 
-The `fontFamily` should be the name you use in CSS for your `font-family` declarations.  The `fontWeight` and `fontStyle` should be either `"normal"` or `"bold"`/`"italic"`.  And the `src` is the path to the font file.
+The following steps demonstrate how to use the module:
 
-Now simply run `kendo-pack-fonts` from that directory:
+1. Place the `.ttf` files of your project in a directory. 
+
+2. Add a file named `fonts.json` that has contents similar to the example below.
+
+    ```
+        [
+            {
+                "fontFamily": "DejaVu Sans",
+                "fontWeight": "normal",
+                "fontStyle": "normal",
+                "src": "./DejaVuSans.ttf"
+            },{
+                "fontFamily": "DejaVu Sans",
+                "fontWeight": "bold",
+                "fontStyle": "normal",
+                "src": "./DejaVuSans-Bold.ttf"
+            },{
+                "fontFamily": "DejaVu Sans",
+                "fontWeight": "normal",
+                "fontStyle": "italic",
+                "src": "./DejaVuSans-Oblique.ttf"
+            },{
+                "fontFamily": "DejaVu Sans",
+                "fontWeight": "bold",
+                "fontStyle": "italic",
+                "src": "./DejaVuSans-BoldOblique.ttf"
+            }
+        ]
+    ```
+    
+    > **Important** 
+    > * The `fontFamily` has to be the name you use in CSS for your `font-family` declarations. 
+    > * The `fontWeight` and `fontStyle` have to be either `"normal"`, `"bold"`, or`"italic"`. 
+    > * The `src` is the path to the font file.
+
+3. Run the `kendo-pack-fonts` command from the directory.
 
     cd /path/to/fonts/directory
     kendo-pack-fonts > fonts.js
 
-Our module bundles the fonts into JS code and dumps it on standard output.  In the example above, we redirected it into a `fonts.js` file.  Now, in your page you should just load it with a script tag:
+    The module bundles the fonts into JavaScript code and dumps it into standard output. In the example above, the code is redirected to a `fonts.js` file. 
 
-    <head>
-      ...
-      <script src="fonts.js"></script>
+4. Load the file with a script file to your page. 
 
-Placing it in `<head>` is not a strict requirement, but we recommend it.  The script will inject `@font-face` declarations into the page with `document.write`.  Do not attempt to load this with RequireJS or similar tools, it will not work.
+    ```
+        <head>
+          ...
+          <script src="fonts.js"></script>
+    ```
+    
+    While placing it in the `<head>` is not a requirement, it is strongly recommended. The script injects the `@font-face` declarations into the page with the `document.write` setup. Do not attempt to load it with RequireJS or similar tools, because it will not work.
 
-Like any compromise, this method has its advantages and drawbacks:
+## Pros and Cons
 
-Pros:
+This approach demonstrates the following advantages and disadvantages:
 
-- Single HTTP request is needed to load all the fonts you use in a page
+|PROS|CONS|
+|:---|:---|
+|To load all the fonts you want to use in a page, you need a single HTTP request. |The size of the generated file is greater than the sum of the sizes of the binary `.ttf` files. However, when you serve JavaScript with the `gzip` compression, you make up for the difference.|
+|You do not have domain security restrictions.|Though you might need just one, all fonts are loaded.|
+|The fonts are available before your page is rendered&mdash;this means that no flickering occurs.|The average time the generated `<script>` spends to create a binary `Blob` from BASE64 is 15 milliseconds per font. The process is faster when you use the classic method of loading the `.ttf` files with plain CSS.|
 
-- No domain security restrictions
+## Browser Support
 
-- The fonts will be available before your page renders (no flickering)
+The generated bundle works in all browsers that support [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob). It is tested against Interenet Explorer 10, Firefox, and Chrome.
 
-Cons:
-
-- The size of the generated file is greater than the sum of the sizes of the binary `.ttf` files.  But serving JS with gzip compression (which you should do anyway) almost makes up for the difference.
-
-- All fonts will be loaded, even if only a few are needed.
-
-- Loading the generated `<script>` spends, on average, 15 milliseconds per font, to create a binary `Blob` from BASE64.  This should be faster than the classic method - loading the `.ttf` files as usual with plain CSS.
-
-## Browser support
-
-The generated bundle should work in all browsers that support [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob).  Tested on IE 10, Firefox, Chrome.
-
-A workaround should be possible for IE9, but it's not yet implemented.
+The team are also working on the implementation of a workaround for Internet Explorer 9.


### PR DESCRIPTION
The removed section should go into the how-to section of the Kendo UI docs