### PR TITLE
fix: change package scope to @progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The packed code works:
 
 To use the module:
 
-1. Install the package by running `npm install -g @telerik/kendo-pack-fonts`.
+1. Install the package by running `npm install -g @progress/kendo-pack-fonts`.
 
 1. Place the `.ttf` files of your project in a directory.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@telerik/kendo-pack-fonts",
-    "version": "0.6.0",
+    "name": "@progress/kendo-pack-fonts",
+    "version": "1.0.0",
     "description": "Utility for packing fonts into inline style declarations",
     "main": "index.js",
     "bin": { "kendo-pack-fonts": "./index.js" },


### PR DESCRIPTION
Cleaning up the `@telerik` scope for internal usage.

Package will be published as @progress/kendo-pack-fonts v1.0.0